### PR TITLE
Add FakeClient wrapper 

### DIFF
--- a/pkg/watcher/fake.go
+++ b/pkg/watcher/fake.go
@@ -1,0 +1,20 @@
+package watcher
+
+import "github.com/civo/civogo"
+
+// FakeClient is a test client used for more flexible behavior control
+// when FakeClient alone is not sufficient.
+type FakeClient struct {
+	HardRebootInstanceFunc func(id string) (*civogo.SimpleResponse, error)
+
+	*civogo.FakeClient
+}
+
+func (f *FakeClient) HardRebootInstance(id string) (*civogo.SimpleResponse, error) {
+	if f.HardRebootInstanceFunc != nil {
+		return f.HardRebootInstanceFunc(id)
+	}
+	return f.FakeClient.HardRebootInstance(id)
+}
+
+var _ civogo.Clienter = (*FakeClient)(nil)


### PR DESCRIPTION
This PR include FakeClient, a test client designed for more flexible behavior control when civogo.FakeClient alone is not sufficient.

## Changes
Added FakeClient, which embeds civogo.FakeClient and allows overriding HardRebootInstance via a function.
Ensured FakeClient satisfies the civogo.Clienter interface at compile time.

## Motivation
The standard civogo.FakeClient may not always provide the required level of flexibility in testing. FakeClient enables customized behavior by allowing function injection for HardRebootInstance, making it easier to control test scenarios. By injecting behavior from the outside, we can perform more flexible and controlled tests.