### PR TITLE
Add node watcher functionality and test case

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.23.5
 
 require (
 	github.com/civo/civogo v0.3.94
+	k8s.io/api v0.32.2
+	k8s.io/apimachinery v0.32.2
 	k8s.io/client-go v0.32.2
 )
 
@@ -42,8 +44,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.32.2 // indirect
-	k8s.io/apimachinery v0.32.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/civo/node-agent
 
-go 1.23.5
+go 1.24.0
 
 require (
 	github.com/civo/civogo v0.3.94

--- a/main.go
+++ b/main.go
@@ -16,13 +16,12 @@ import (
 var versionInfo = flag.Bool("version", false, "Print the driver version")
 
 var (
-	apiURL     = strings.TrimSpace(os.Getenv("CIVO_API_URL"))
-	apiKey     = strings.TrimSpace(os.Getenv("CIVO_API_KEY"))
-	region     = strings.TrimSpace(os.Getenv("CIVO_REGION"))
-	clusterID  = strings.TrimSpace(os.Getenv("CIVO_CLUSTER_ID"))
-	nodePoolID = strings.TrimSpace(os.Getenv("CIVO_NODE_POOL_ID"))
-
-	// TODO: GPU count
+	apiURL              = strings.TrimSpace(os.Getenv("CIVO_API_URL"))
+	apiKey              = strings.TrimSpace(os.Getenv("CIVO_API_KEY"))
+	region              = strings.TrimSpace(os.Getenv("CIVO_REGION"))
+	clusterID           = strings.TrimSpace(os.Getenv("CIVO_CLUSTER_ID"))
+	nodePoolID          = strings.TrimSpace(os.Getenv("CIVO_NODE_POOL_ID"))
+	nodeDesiredGPUCount = strings.TrimSpace(os.Getenv("CIVO_NODE_DESIRED_GPU_COUNT"))
 )
 
 func run(ctx context.Context) error {

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func run(ctx context.Context) error {
 		cancel()
 	}()
 
-	w, err := watcher.NewWatcher(ctx, apiURL, apiKey, region, clusterID, nodePoolID)
+	w, err := watcher.NewWatcher(ctx, apiURL, apiKey, region, clusterID, nodePoolID, nodeDesiredGPUCount)
 	if err != nil {
 		return err
 	}

--- a/pkg/watcher/fake.go
+++ b/pkg/watcher/fake.go
@@ -5,7 +5,8 @@ import "github.com/civo/civogo"
 // FakeClient is a test client used for more flexible behavior control
 // when FakeClient alone is not sufficient.
 type FakeClient struct {
-	HardRebootInstanceFunc func(id string) (*civogo.SimpleResponse, error)
+	HardRebootInstanceFunc            func(id string) (*civogo.SimpleResponse, error)
+	FindKubernetesClusterInstanceFunc func(clusterID, search string) (*civogo.Instance, error)
 
 	*civogo.FakeClient
 }
@@ -15,6 +16,13 @@ func (f *FakeClient) HardRebootInstance(id string) (*civogo.SimpleResponse, erro
 		return f.HardRebootInstanceFunc(id)
 	}
 	return f.FakeClient.HardRebootInstance(id)
+}
+
+func (f *FakeClient) FindKubernetesClusterInstance(clusterID, search string) (*civogo.Instance, error) {
+	if f.FindKubernetesClusterInstanceFunc != nil {
+		return f.FindKubernetesClusterInstanceFunc(clusterID, search)
+	}
+	return f.FakeClient.FindKubernetesClusterInstance(clusterID, search)
 }
 
 var _ civogo.Clienter = (*FakeClient)(nil)

--- a/pkg/watcher/options.go
+++ b/pkg/watcher/options.go
@@ -1,6 +1,38 @@
 package watcher
 
+import (
+	"github.com/civo/civogo"
+	"k8s.io/client-go/kubernetes"
+)
+
 // Option represents a configuration function that modifies watcher object.
 type Option func(*watcher)
 
 var defaultOptions = []Option{}
+
+// WithKubernetesClient returns Option to set Kubernetes API client.
+func WithKubernetesClient(client kubernetes.Interface) Option {
+	return func(w *watcher) {
+		if client != nil {
+			w.client = client
+		}
+	}
+}
+
+// WithKubernetesClient returns Option to set Kubernetes config path.
+func WithKubernetesClientConfigPath(path string) Option {
+	return func(w *watcher) {
+		if path != "" {
+			w.clientCfgPath = path
+		}
+	}
+}
+
+// WithCivoClient returns Option to set Civo API client.
+func WithCivoClient(client civogo.Clienter) Option {
+	return func(w *watcher) {
+		if client != nil {
+			w.civoClient = client
+		}
+	}
+}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -118,7 +118,7 @@ func (w *watcher) setupCivoClient() error {
 
 	client, err := civogo.NewClientWithURL(w.apiKey, w.apiURL, w.region)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to intiliase civo client: %w", err)
 	}
 
 	userAgent := &civogo.Component{
@@ -162,7 +162,7 @@ func (w *watcher) run(ctx context.Context) error {
 			slog.Info("Node is not ready, attempting to reboot", "node", node.GetName())
 			if err := w.rebootNode(node.GetName()); err != nil {
 				slog.Error("Failed to reboot Node", "node", node.GetName(), "error", err)
-				return err
+				return fmt.Errorf("failed to reboot node: %w", err)
 			}
 		}
 	}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -150,6 +150,7 @@ func (w *watcher) Run(ctx context.Context) error {
 }
 
 func (w *watcher) run(ctx context.Context) error {
+	// TODO: Change to WatchAPI later.
 	nodes, err := w.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{
 		LabelSelector: metav1.FormatLabelSelector(w.nodeSelector),
 	})

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/civo/civogo"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/client-go/kubernetes"
@@ -22,7 +21,7 @@ var Version string = "0.0.1"
 
 const (
 	nodePoolLabelKey = "kubernetes.civo.com/civo-node-pool"
-	gpuStasName      = "nvidia.com/gpu"
+	gpuResourceName  = "nvidia.com/gpu"
 )
 
 type Watcher interface {
@@ -170,7 +169,7 @@ func (w *watcher) run(ctx context.Context) error {
 	return nil
 }
 
-func isNodeReady(node *v1.Node) bool {
+func isNodeReady(node *corev1.Node) bool {
 	for _, cond := range node.Status.Conditions {
 		if cond.Type == corev1.NodeReady {
 			return cond.Status == corev1.ConditionTrue
@@ -179,8 +178,8 @@ func isNodeReady(node *v1.Node) bool {
 	return false
 }
 
-func isNodeDesiredGPU(node *v1.Node, desired int) bool {
-	quantity := node.Status.Allocatable[gpuStasName]
+func isNodeDesiredGPU(node *corev1.Node, desired int) bool {
+	quantity := node.Status.Allocatable[gpuResourceName]
 	if quantity.IsZero() {
 		return false
 	}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -150,7 +150,6 @@ func (w *watcher) Run(ctx context.Context) error {
 }
 
 func (w *watcher) run(ctx context.Context) error {
-	// TODO: Change to WatchAPI later.
 	nodes, err := w.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{
 		LabelSelector: metav1.FormatLabelSelector(w.nodeSelector),
 	})

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -11,11 +11,12 @@ import (
 )
 
 var (
-	testClusterID  = "test-cluster-123"
-	testRegion     = "lon1"
-	testApiKey     = "test-api-key"
-	testApiURL     = "https://test.civo.com"
-	testnodePoolID = "test-node-pool"
+	testClusterID           = "test-cluster-123"
+	testRegion              = "lon1"
+	testApiKey              = "test-api-key"
+	testApiURL              = "https://test.civo.com"
+	testnodePoolID          = "test-node-pool"
+	testNodeDesiredGPUCount = "8"
 )
 
 func TestIsNodeReady(t *testing.T) {
@@ -180,7 +181,7 @@ func TestRebootNode(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			w, err := NewWatcher(t.Context(),
-				testApiURL, testApiKey, testRegion, testClusterID, testnodePoolID, test.args.opts...)
+				testApiURL, testApiKey, testRegion, testClusterID, testnodePoolID, testNodeDesiredGPUCount, test.args.opts...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -1,0 +1,199 @@
+package watcher
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/civo/civogo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var (
+	testClusterID  = "test-cluster-123"
+	testRegion     = "lon1"
+	testApiKey     = "test-api-key"
+	testApiURL     = "https://test.civo.com"
+	testnodePoolID = "test-node-pool"
+)
+
+func TestIsNodeReady(t *testing.T) {
+	type test struct {
+		name string
+		node *corev1.Node
+		want bool
+	}
+
+	tests := []test{
+		{
+			name: "Returns true when Node is ready state",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-01",
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Returns false when Node is not ready state",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-01",
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Returns false when no conditions for the node",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-01",
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := isNodeReady(test.node)
+			if got != test.want {
+				t.Errorf("got = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRebootNode(t *testing.T) {
+	type args struct {
+		nodeName string
+		opts     []Option
+	}
+	type test struct {
+		name       string
+		args       args
+		beforeFunc func(*testing.T, *watcher)
+		wantErr    bool
+	}
+
+	tests := []test{
+		{
+			name: "Returns nil when there is no error finding and rebooting the instance",
+			args: args{
+				nodeName: "node-01",
+				opts: []Option{
+					WithKubernetesClient(fake.NewSimpleClientset()),
+					WithCivoClient(&FakeClient{}),
+				},
+			},
+			beforeFunc: func(t *testing.T, w *watcher) {
+				t.Helper()
+				client := w.civoClient.(*FakeClient)
+
+				instance := &civogo.Instance{
+					ID: "instance-01",
+				}
+
+				client.FindKubernetesClusterInstanceFunc = func(clusterID, search string) (*civogo.Instance, error) {
+					return instance, nil
+				}
+				client.HardRebootInstanceFunc = func(id string) (*civogo.SimpleResponse, error) {
+					if instance.ID != id {
+						t.Errorf("instanceId dose not match. want: %s, but got: %s", instance.ID, id)
+					}
+					return new(civogo.SimpleResponse), nil
+				}
+			},
+		},
+		{
+			name: "Returns an error when instance lookup fails",
+			args: args{
+				nodeName: "node-01",
+				opts: []Option{
+					WithKubernetesClient(fake.NewSimpleClientset()),
+					WithCivoClient(&FakeClient{}),
+				},
+			},
+			beforeFunc: func(t *testing.T, w *watcher) {
+				t.Helper()
+				client := w.civoClient.(*FakeClient)
+
+				client.FindKubernetesClusterInstanceFunc = func(clusterID, search string) (*civogo.Instance, error) {
+					return nil, errors.New("invalid error")
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "Returns an error when instance reboot fails",
+			args: args{
+				nodeName: "node-01",
+				opts: []Option{
+					WithKubernetesClient(fake.NewSimpleClientset()),
+					WithCivoClient(&FakeClient{}),
+				},
+			},
+			beforeFunc: func(t *testing.T, w *watcher) {
+				t.Helper()
+				client := w.civoClient.(*FakeClient)
+
+				instance := &civogo.Instance{
+					ID: "instance-01",
+				}
+
+				client.FindKubernetesClusterInstanceFunc = func(clusterID, search string) (*civogo.Instance, error) {
+					return instance, nil
+				}
+				client.HardRebootInstanceFunc = func(id string) (*civogo.SimpleResponse, error) {
+					if instance.ID != id {
+						t.Errorf("instanceId dose not match. want: %s, but got: %s", instance.ID, id)
+					}
+					return nil, errors.New("invalid error")
+				}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			w, err := NewWatcher(t.Context(),
+				testApiURL, testApiKey, testRegion, testClusterID, testnodePoolID, test.args.opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			obj := w.(*watcher)
+			if test.beforeFunc != nil {
+				test.beforeFunc(t, obj)
+			}
+
+			err = obj.rebootNode(test.args.nodeName)
+			if (err != nil) != test.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR includes the implementation of a watcher that periodically checks the status of nodes in a Kubernetes cluster, specifically focusing on the availability of GPUs and the readiness of the nodes.

The watcher works as follows:

 it fetches the list of nodes that match the specified selector.
It then checks if the node meets the desired GPU count and whether the node is in a ready state. If either condition is not met, the node is considered unready.
If a node is found to be unready or doesn't have the expected GPU count, the watcher attempts to reboot the node by invoking a reboot on the corresponding instance in Civo.
This functionality ensures that nodes are automatically monitored and rebooted if necessary to meet the specified conditions, maintaining optimal performance and readiness.


:warning:  It also includes the necessary test cases to validate the functionality. I am currently checking the GPU part, so some corrections might be made later, but the implementation and tests are complete for now.
