### PR TITLE
Fix missing argument assignments in NewWatcher

### DIFF
--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -10,7 +10,6 @@ import (
 	"github.com/civo/civogo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -43,7 +42,12 @@ type watcher struct {
 }
 
 func NewWatcher(ctx context.Context, apiURL, apiKey, region, clusterID, nodePoolID, nodeDesiredGPUCount string, opts ...Option) (Watcher, error) {
-	w := new(watcher)
+	w := &watcher{
+		clusterID: clusterID,
+		apiKey:    apiKey,
+		apiURL:    apiURL,
+		region:    region,
+	}
 	for _, opt := range append(defaultOptions, opts...) {
 		opt(w)
 	}


### PR DESCRIPTION
This PR fixes an issue where certain arguments were not correctly assigned to the watcher struct in NewWatcher.

## Changes:
- Fixed missing assignments of specific fields in watcher.
- Added test cases to verify correct field assignments.

Ensured test cases handle error scenarios properly to avoid nil dereference issues.
These changes improve the correctness of the implementation and the reliability of tests.



:warning:  In v0.1.0, this issue results in an error. However, this implementation is expected to fix the error, so a new version release will be required.

cc: @johndietz 