### PR TITLE
feat: change gpu count logic

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -2,9 +2,9 @@ replicaCount: 1
 
 
 image:
-  repository: johndietz/node-agent
+  repository: jokesta/na
   pullPolicy: IfNotPresent
-  tag: "1.4"
+  tag: "0.23"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Description

The previous logic for checking GPU availability:  

```go
quantity, exists := node.Status.Allocatable[gpuResourceName]
if !exists || quantity.IsZero() {
    slog.Info("read allocatable gpus", "node", node.GetName(), "count", quantity.String())
    return false
}
```
was incorrect because node.Status.Allocatable[gpuResourceName] does not exist in the YAML.
The logic has been updated to query the Civo API instead of relying on the missing field.