### PR TITLE
Add option to set desired GPU count

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,8 +28,9 @@ func run(ctx context.Context) error {
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	w, err := watcher.NewWatcher(ctx, apiURL, apiKey, region, clusterID, nodePoolID, nodeDesiredGPUCount,
+	w, err := watcher.NewWatcher(ctx, apiURL, apiKey, region, clusterID, nodePoolID,
 		watcher.WithRebootTimeWindowMinutes(rebootTimeWindowMinutes),
+		watcher.WithDesiredGPUCount(nodeDesiredGPUCount),
 	)
 	if err != nil {
 		return err

--- a/pkg/watcher/options.go
+++ b/pkg/watcher/options.go
@@ -56,7 +56,7 @@ func WithRebootTimeWindowMinutes(s string) Option {
 	}
 }
 
-// WithDesiredGPUCount returns Option to set reboot time window.
+// WithDesiredGPUCount returns Option to set desired GPU count .
 func WithDesiredGPUCount(s string) Option {
 	return func(w *watcher) {
 		n, err := strconv.Atoi(s)

--- a/pkg/watcher/options.go
+++ b/pkg/watcher/options.go
@@ -1,6 +1,7 @@
 package watcher
 
 import (
+	"log/slog"
 	"strconv"
 	"time"
 
@@ -13,6 +14,7 @@ type Option func(*watcher)
 
 var defaultOptions = []Option{
 	WithRebootTimeWindowMinutes("40"),
+	WithDesiredGPUCount("0"),
 }
 
 // WithKubernetesClient returns Option to set Kubernetes API client.
@@ -48,6 +50,20 @@ func WithRebootTimeWindowMinutes(s string) Option {
 		n, err := strconv.Atoi(s)
 		if err == nil && n > 0 {
 			w.rebootTimeWindowMinutes = time.Duration(n)
+		} else {
+			slog.Info("RebootTimeWindowMinutes is invalid", "value", s)
+		}
+	}
+}
+
+// WithDesiredGPUCount returns Option to set reboot time window.
+func WithDesiredGPUCount(s string) Option {
+	return func(w *watcher) {
+		n, err := strconv.Atoi(s)
+		if err == nil && n >= 0 {
+			w.nodeDesiredGPUCount = n
+		} else {
+			slog.Info("DesiredGPUCount is invalid", "value", s)
 		}
 	}
 }

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -42,7 +42,7 @@ type watcher struct {
 	nodeSelector *metav1.LabelSelector
 }
 
-func NewWatcher(ctx context.Context, apiURL, apiKey, region, clusterID, nodePoolID, nodeDesiredGPUCount string, opts ...Option) (Watcher, error) {
+func NewWatcher(ctx context.Context, apiURL, apiKey, region, clusterID, nodePoolID string, opts ...Option) (Watcher, error) {
 	w := &watcher{
 		clusterID: clusterID,
 		apiKey:    apiKey,
@@ -63,12 +63,6 @@ func NewWatcher(ctx context.Context, apiURL, apiKey, region, clusterID, nodePool
 		return nil, fmt.Errorf("CIVO_API_KEY not set")
 	}
 
-	n, err := strconv.Atoi(nodeDesiredGPUCount)
-	if err != nil {
-		return nil, fmt.Errorf("CIVO_NODE_DESIRED_GPU_COUNT has an invalid value, %s: %w", nodeDesiredGPUCount, err)
-	}
-
-	w.nodeDesiredGPUCount = n
 	w.nodeSelector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			nodePoolLabelKey: nodePoolID,
@@ -212,7 +206,7 @@ func isNodeReady(node *corev1.Node) bool {
 
 func isNodeDesiredGPU(node *corev1.Node, desired int) bool {
 	if desired == 0 {
-		slog.Info("Desired GPU count is set to 0", "node", node.GetName())
+		slog.Info("Desired GPU count is set to 0, so the GPU count check was skipped", "node", node.GetName())
 		return true
 	}
 

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -206,7 +206,7 @@ func isNodeReady(node *corev1.Node) bool {
 
 func isNodeDesiredGPU(node *corev1.Node, desired int) bool {
 	if desired == 0 {
-		slog.Info("Desired GPU count is set to 0, so the GPU count check was skipped", "node", node.GetName())
+		slog.Info("Desired GPU count is set to 0, so the GPU count check is skipped", "node", node.GetName())
 		return true
 	}
 

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -693,7 +693,7 @@ func TestIsNodeDesiredGPU(t *testing.T) {
 			want:    true,
 		},
 		{
-			name: "Returns true when desired GPU count is, so count check is skipped",
+			name: "Returns true when desired GPU count is 0, so count check is skipped",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-01",


### PR DESCRIPTION
This PR modifies the application to allow setting the desired GPU count via an functional option.
Since having a variable in the New function about gpu count makes it look like a required parameter, it is better to set it via an option instead.


## Summary

If the desired GPU count is not set via environment variables, it defaults to 0.
When the desired GPU count is 0, GPU count checking is skipped.
This enables node-agent to run in both GPU and non-GPU environments.

## Behavior
- GPU environments:
  - The existing two conditions for checks remain unchanged:
    - The node enters the NotReady state.
    - The number of available GPUs per node falls below a configured threshold.

- Non-GPU environments:
  - GPU count checking is skipped.
  - Only the NotReady state condition is evaluated.


This enhancement improves flexibility by supporting both GPU-equipped and non-GPU environments seamlessly.

**This is not urgent, so it's fine to include it with the next release.**