### PR TITLE
Fix to prevent consecutive reboots in case of reboot delay.

### DIFF
--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -208,7 +208,7 @@ func isReadyOrNotReadyStatusChangedAfter(node *corev1.Node, thresholdTime time.T
 // NOTE: This is only effective when running with a single node-agent. If we want to run multiple instances, additional logic modifications will be required.
 func (w *watcher) isLastRebootTimeAfter(nodeName string, thresholdTime time.Time) bool {
 	v, ok := w.lastRebootTimes.Load(nodeName)
-	if ok {
+	if !ok {
 		slog.Info("LastRebootTime not found", "node", nodeName)
 		return false
 	}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -161,6 +161,13 @@ func (w *watcher) run(ctx context.Context) error {
 
 	for _, node := range nodes.Items {
 		if !isNodeDesiredGPU(&node, w.nodeDesiredGPUCount) || !isNodeReady(&node) {
+
+			// LTT: LastTransitionTime of node.
+			// LRCT: LastRebootCmdTimes
+			// - LTT > 60 , LRCT < 60 dont reboot
+			// - LTT < 60 , LRCT < 60 dont reboot
+			// - LTT < 60 , LRCT > 60 dont reboot
+			// - LTT > 60, LRCT >. 60 reboot
 			slog.Info("Node is not ready, attempting to reboot", "node", node.GetName())
 			if isReadyOrNotReadyStatusChangedAfter(&node, thresholdTime) {
 				slog.Info("Skipping reboot because Ready/NotReady status was updated recently", "node", node.GetName())

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -162,8 +162,9 @@ func (w *watcher) run(ctx context.Context) error {
 	for _, node := range nodes.Items {
 		if !isNodeDesiredGPU(&node, w.nodeDesiredGPUCount) || !isNodeReady(&node) {
 
-			// LTT: LastTransitionTime of node.
+			// LTT:  LastTransitionTime of node.
 			// LRCT: LastRebootCmdTimes
+			// 60:   Threshold time (example)
 			// - LTT > 60 , LRCT < 60 dont reboot
 			// - LTT < 60 , LRCT < 60 dont reboot
 			// - LTT < 60 , LRCT > 60 dont reboot

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -203,6 +203,7 @@ func isReadyOrNotReadyStatusChangedAfter(node *corev1.Node, thresholdTime time.T
 // is after the given threshold time. In case of delays in reboot, the
 // LastTransitionTime of node might not be updated, so it compares the latest reboot
 // time to prevent sending reboot commands multiple times.
+// NOTE: This is only effective when running with a single node-agent. If you want to run multiple instances, additional logic modifications will be required.
 func (w *watcher) isLastRebootTimeAfter(nodeName string, thresholdTime time.Time) bool {
 	v, ok := w.lastRebootTime.Load(nodeName)
 	if ok {

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -219,7 +219,7 @@ func (w *watcher) isLastRebootTimeAfter(nodeName string, thresholdTime time.Time
 		return false
 	}
 
-	slog.Info("Checking if Ready/NotReady status has changed recently",
+	slog.Info("Checking if LastRebootTime has changed recently",
 		"node", nodeName,
 		"lastRebootTime", lastRebootTime.String(),
 		"thresholdTime", thresholdTime.String())

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -369,6 +369,50 @@ func TestRun(t *testing.T) {
 				t.Helper()
 				client := w.client.(*fake.Clientset)
 
+				w.lastRebootCmdTimes.Store("node-01", time.Now())
+
+				nodes := &corev1.NodeList{
+					Items: []corev1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "node-01",
+								Labels: map[string]string{
+									nodePoolLabelKey: testNodePoolID,
+								},
+							},
+							Status: corev1.NodeStatus{
+								Conditions: []corev1.NodeCondition{
+									{
+										Type:   corev1.NodeReady,
+										Status: corev1.ConditionFalse,
+									},
+								},
+								Allocatable: corev1.ResourceList{
+									gpuResourceName: resource.MustParse("8"),
+								},
+							},
+						},
+					},
+				}
+				client.Fake.PrependReactor("list", "nodes", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nodes, nil
+				})
+			},
+		},
+		{
+			name: "Returns nil and skips reboot when GPU count matches desired but node is not ready, and LastRebootCmdTime is more recent than thresholdTime",
+			args: args{
+				opts: []Option{
+					WithKubernetesClient(fake.NewSimpleClientset()),
+					WithCivoClient(&FakeClient{}),
+					WithDesiredGPUCount(testNodeDesiredGPUCount),
+				},
+				nodePoolID: testNodePoolID,
+			},
+			beforeFunc: func(w *watcher) {
+				t.Helper()
+				client := w.client.(*fake.Clientset)
+
 				nodes := &corev1.NodeList{
 					Items: []corev1.Node{
 						{

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -600,6 +600,88 @@ func TestIsReadyOrNotReadyStatusChangedAfter(t *testing.T) {
 	}
 }
 
+func TestIsLastRebootCommandTimeAfter(t *testing.T) {
+	type test struct {
+		name          string
+		nodeName      string
+		opts          []Option
+		thresholdTime time.Time
+		beforeFunc    func(*watcher)
+		want          bool
+	}
+
+	tests := []test{
+		{
+			name: "Return true when last reboot command time is after threshold",
+			opts: []Option{
+				WithKubernetesClient(fake.NewSimpleClientset()),
+				WithCivoClient(&FakeClient{}),
+			},
+			nodeName:      "node-01",
+			thresholdTime: time.Now().Add(-time.Hour),
+			beforeFunc: func(w *watcher) {
+				w.lastRebootCmdTimes.Store("node-01", time.Now())
+			},
+			want: true,
+		},
+		{
+			name: "Return false when last reboot command time is before threshold",
+			opts: []Option{
+				WithKubernetesClient(fake.NewSimpleClientset()),
+				WithCivoClient(&FakeClient{}),
+			},
+			nodeName:      "node-01",
+			thresholdTime: time.Now().Add(-time.Hour),
+			beforeFunc: func(w *watcher) {
+				w.lastRebootCmdTimes.Store("nodde-01", time.Now().Add(-2*time.Hour))
+			},
+			want: false,
+		},
+		{
+			name: "Return false when last reboot command time not found",
+			opts: []Option{
+				WithKubernetesClient(fake.NewSimpleClientset()),
+				WithCivoClient(&FakeClient{}),
+			},
+			nodeName:      "node-01",
+			thresholdTime: time.Now().Add(-time.Hour),
+			want:          false,
+		},
+		{
+			name: "Return false when type of last reboot command time is invalid",
+			opts: []Option{
+				WithKubernetesClient(fake.NewSimpleClientset()),
+				WithCivoClient(&FakeClient{}),
+			},
+			nodeName:      "node-01",
+			thresholdTime: time.Now().Add(-time.Hour),
+			beforeFunc: func(w *watcher) {
+				w.lastRebootCmdTimes.Store("nodde-01", "invalid-type")
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			w, err := NewWatcher(t.Context(),
+				testApiURL, testApiKey, testRegion, testClusterID, testNodePoolID, test.opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			obj := w.(*watcher)
+			if test.beforeFunc != nil {
+				test.beforeFunc(obj)
+			}
+			got := obj.isLastRebootCommandTimeAfter(test.nodeName, test.thresholdTime)
+			if got != test.want {
+				t.Errorf("got = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestIsNodeReady(t *testing.T) {
 	type test struct {
 		name string


### PR DESCRIPTION
## WHAT

This PR contains the following changes:
- Implemented the isLastRebootCmdTimeAfter function, which checks if the last reboot command time for a specified node is after the given threshold time.

## WHY

In this case, there was a scenario where the reboot was delayed for over 60 minutes. As a result, the node's LastTransitionTime remained unchanged, causing reboot commands to be issued every time. In other words, since the node's  LastTransitionTime didn't change for 60 minutes, the node-agent's check loop continued to trigger, resulting in multiple reboot commands being sent during that time.

To address this, I considered it necessary to use both the node's LastTransitionTime and LastRebootCmdTime (the actual time the reboot command was sent) to handle such cases. This dual comparison ensures that reboot commands are not repeatedly triggered in the event of delays, effectively preventing unnecessary reboots.

